### PR TITLE
Migrate rate-limit storage to Redis sorted sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ Javadoc is available at https://javadoc.jitpack.io/com/github/jfisbein/java-rate
 Limitations
 -----------
 
-As no synchronization method is implemented, some edge race conditions could lead to get a false positive or negative response from the
-method `canDoEvent`. 
+Event attempts are stored in Redis sorted sets (score = epoch millis) and pruned by time window. As no synchronization method is
+implemented around the full `canDoEvent` + `doEvent` workflow, some edge race conditions could still lead to false positive or
+negative responses under heavy concurrency.

--- a/src/main/java/org/sputnik/ratelimit/dao/EventsRedisRepository.java
+++ b/src/main/java/org/sputnik/ratelimit/dao/EventsRedisRepository.java
@@ -68,15 +68,15 @@ public class EventsRedisRepository {
    * @return First event date or null if no events are found.
    */
   public Instant getOldestEvent(String eventId, String key) {
-    Instant result = null;
     try (Jedis jedis = jedisPool.getResource()) {
-      for (Tuple tuple : jedis.zrangeWithScores(eventKey(eventId, key), 0, 0)) {
-        result = Instant.ofEpochMilli((long) tuple.getScore());
-        break;
+      var iterator = jedis.zrangeWithScores(eventKey(eventId, key), 0, 0).iterator();
+      if (iterator.hasNext()) {
+        Tuple tuple = iterator.next();
+        return Instant.ofEpochMilli((long) tuple.getScore());
       }
     }
 
-    return result;
+    return null;
   }
 
   /**

--- a/src/main/java/org/sputnik/ratelimit/dao/EventsRedisRepository.java
+++ b/src/main/java/org/sputnik/ratelimit/dao/EventsRedisRepository.java
@@ -3,17 +3,16 @@ package org.sputnik.ratelimit.dao;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.UUID;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.resps.Tuple;
 
 /**
  * Repository to manage Events persistence.
  */
 public class EventsRedisRepository {
 
-  private static final Logger logger = LoggerFactory.getLogger(EventsRedisRepository.class);
   protected static final String KEY_SEPARATOR = "-";
   protected final JedisPool jedisPool;
 
@@ -36,9 +35,11 @@ public class EventsRedisRepository {
   public void addEvent(String eventId, String key, Duration duration) {
     try (Jedis jedis = jedisPool.getResource()) {
       String redisKey = eventKey(eventId, key);
-      jedis.rpush(redisKey, Long.toString(System.currentTimeMillis()));
+      long now = System.currentTimeMillis();
+      String member = UUID.randomUUID().toString();
+      jedis.zadd(redisKey, now, member);
       if (duration != null) {
-        jedis.expire(redisKey, (int) duration.getSeconds());
+        jedis.pexpire(redisKey, Math.max(1, duration.toMillis()));
       }
     }
   }
@@ -50,75 +51,46 @@ public class EventsRedisRepository {
    * @param key     Key.
    * @return number of events.
    */
-  public long getListLength(String eventId, String key) {
+  public long getEventsCount(String eventId, String key) {
     long result;
     try (Jedis jedis = jedisPool.getResource()) {
-      result = jedis.llen(eventKey(eventId, key));
+      result = jedis.zcard(eventKey(eventId, key));
     }
 
     return result;
   }
 
   /**
-   * Get first list element date for an event id, and a key.
+   * Get oldest event timestamp for an event id, and a key.
    *
    * @param eventId Event id.
    * @param key     Key.
-   * @return First list element.
+   * @return First event date or null if no events are found.
    */
-  public Instant getListFirstElement(String eventId, String key) {
-    Instant result;
-    try (Jedis jedis = jedisPool.getResource()) {
-      String aux = jedis.lindex(eventKey(eventId, key), 0);
-      result = parseTimeStamp(aux);
-    }
-
-    return result;
-  }
-
-  public Instant getListFirstEventElement(String eventId, String key, Long eventMaxIntents) {
-    Instant result;
-    try (Jedis jedis = jedisPool.getResource()) {
-      String redisKey = eventKey(eventId, key);
-      long length = jedis.llen(redisKey);
-      long index = Math.max(0, length - eventMaxIntents);
-      String aux = jedis.lindex(redisKey, index);
-      result = parseTimeStamp(aux);
-    }
-
-    return result;
-  }
-
-  /**
-   * Remove first list element for an event id, and a key.
-   *
-   * @param eventId Event id.
-   * @param key     Key.
-   * @return first list element.
-   */
-  public Instant removeListFirstElement(String eventId, String key) {
+  public Instant getOldestEvent(String eventId, String key) {
     Instant result = null;
-    String aux;
     try (Jedis jedis = jedisPool.getResource()) {
-      aux = jedis.lpop(eventKey(eventId, key));
-      if (aux != null) {
-        result = parseTimeStamp(aux);
+      for (Tuple tuple : jedis.zrangeWithScores(eventKey(eventId, key), 0, 0)) {
+        result = Instant.ofEpochMilli((long) tuple.getScore());
+        break;
       }
     }
 
     return result;
   }
 
-  private Instant parseTimeStamp(String textTimeInMillis) {
-    Instant instant = null;
-
-    try {
-      instant = Instant.ofEpochMilli(Long.parseLong(textTimeInMillis));
-    } catch (NumberFormatException e) {
-      logger.warn("Error parsing date: {}", textTimeInMillis);
+  /**
+   * Remove all events older than threshold instant, using an exclusive upper bound.
+   *
+   * @param eventId    Event id.
+   * @param key        Key.
+   * @param threshold  Threshold instant.
+   * @return number of removed entries.
+   */
+  public long removeEventsOlderThan(String eventId, String key, Instant threshold) {
+    try (Jedis jedis = jedisPool.getResource()) {
+      return jedis.zremrangeByScore(eventKey(eventId, key), "-inf", "(" + threshold.toEpochMilli());
     }
-
-    return instant;
   }
 
   /**

--- a/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
+++ b/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
@@ -1,17 +1,5 @@
 package org.sputnik.ratelimit.service;
 
-import java.io.Closeable;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sputnik.ratelimit.dao.EventsRedisRepository;
@@ -21,246 +9,271 @@ import org.sputnik.ratelimit.util.EventConfig;
 import org.sputnik.ratelimit.util.Hasher;
 import redis.clients.jedis.JedisPool;
 
+import java.io.Closeable;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public class RateLimiter implements Closeable {
 
-  private static final Logger logger = LoggerFactory.getLogger(RateLimiter.class);
-  private final EventsRedisRepository eventsRedisRepository;
-  private final Map<String, EventConfig> eventsConfig;
-  private final JedisPool jedisPool;
-  private final Hasher hasher;
-  private final Map<String, String> hashCache = new ConcurrentHashMap<>();
-
-
-  /**
-   * Constructor.
-   *
-   * @param jedisConf     Jedis configuration.
-   * @param hashingSecret secret for hashing values
-   * @param eventConfigs  Events configuration.
-   */
-  public RateLimiter(JedisConfiguration jedisConf, String hashingSecret, EventConfig... eventConfigs) {
-    jedisPool = jedisConf.createPool();
-    eventsRedisRepository = new EventsRedisRepository(jedisPool);
-    validateEventsConfig(eventConfigs);
-    eventsConfig = Stream.of(eventConfigs).collect(Collectors.toMap(EventConfig::eventId, Function.identity()));
-    hasher = new Hasher(hashingSecret);
-  }
-
-  /**
-   * Constructor.
-   *
-   * @param host          Redis host.
-   * @param port          Redis port.
-   * @param hashingSecret secret for hashing values
-   * @param eventConfigs  Events configuration.
-   */
-  public RateLimiter(String host, int port, String hashingSecret, EventConfig... eventConfigs) {
-    this(JedisConfiguration.builder().host(host).port(port).build(), hashingSecret, eventConfigs);
-  }
-
-  /**
-   * Checks if the event can be done without exceeding the configured limits.
-   *
-   * @param eventId Event identifier.
-   * @param key     event execution key.
-   * @return Response object with information about if the event can be done, the reason, and wait time if it cannot be done because
-   * exceeding event limits.
-   */
-  public CanDoResponse canDoEvent(String eventId, String key) {
-    CanDoResponse response;
-    if (isValidRequest(eventId, key)) {
-      logger.debug("Event ({}) exists, checking if it could be performed", eventId);
-
-      String hashedKey = hashText(key);
-      EventConfig eventConfig = eventsConfig.get(eventId);
-      Duration eventTime = eventConfig.minTime();
-      long eventMaxIntents = eventConfig.maxIntents();
-      Instant now = Instant.now();
-      eventsRedisRepository.removeEventsOlderThan(eventId, hashedKey, now.minus(eventTime));
-      long eventIntents = eventsRedisRepository.getEventsCount(eventId, hashedKey);
-
-      if (eventIntents >= eventMaxIntents) {
-        logger.debug("Checking dates");
-        Instant firstDate = eventsRedisRepository.getOldestEvent(eventId, hashedKey);
-        if (firstDate == null) {
-          logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
-          response = CanDoResponse.success(eventIntents);
-        } else {
-          long millisDifference = ChronoUnit.MILLIS.between(firstDate, now);
-          response = CanDoResponse.tooMany(Math.max(0, eventTime.toMillis() - millisDifference), eventIntents);
+    private static final Logger logger = LoggerFactory.getLogger(RateLimiter.class);
+    /**
+     * Maximum number of plain-text key -> hashed-key entries kept in memory.
+     */
+    private static final int MAX_HASHED_KEY_CACHE_ENTRIES = 10_000;
+    private final EventsRedisRepository eventsRedisRepository;
+    private final Map<String, EventConfig> eventsConfig;
+    private final JedisPool jedisPool;
+    private final Hasher hasher;
+    private final Map<String, String> hashCache = new LinkedHashMap<>(16, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+            return size() > MAX_HASHED_KEY_CACHE_ENTRIES;
         }
-      } else {
-        logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
-        response = CanDoResponse.success(eventIntents);
-      }
-    } else {
-      response = CanDoResponse.invalidRequest();
+    };
+
+
+    /**
+     * Constructor.
+     *
+     * @param jedisConf     Jedis configuration.
+     * @param hashingSecret secret for hashing values
+     * @param eventConfigs  Events configuration.
+     */
+    public RateLimiter(JedisConfiguration jedisConf, String hashingSecret, EventConfig... eventConfigs) {
+        jedisPool = jedisConf.createPool();
+        eventsRedisRepository = new EventsRedisRepository(jedisPool);
+        validateEventsConfig(eventConfigs);
+        eventsConfig = Stream.of(eventConfigs).collect(Collectors.toMap(EventConfig::eventId, Function.identity()));
+        hasher = new Hasher(hashingSecret);
     }
 
-    if (!response.canDo()) {
-      logger.info("The event: {} could NOT be performed. reason: {}. need to wait: {} ms",
-        eventId, response.reason(), response.waitMillis());
+    /**
+     * Constructor.
+     *
+     * @param host          Redis host.
+     * @param port          Redis port.
+     * @param hashingSecret secret for hashing values
+     * @param eventConfigs  Events configuration.
+     */
+    public RateLimiter(String host, int port, String hashingSecret, EventConfig... eventConfigs) {
+        this(JedisConfiguration.builder().host(host).port(port).build(), hashingSecret, eventConfigs);
     }
 
-    return response;
-  }
+    /**
+     * Checks if the event can be done without exceeding the configured limits.
+     *
+     * @param eventId Event identifier.
+     * @param key     event execution key.
+     * @return Response object with information about if the event can be done, the reason, and wait time if it cannot be done because
+     * exceeding event limits.
+     */
+    public CanDoResponse canDoEvent(String eventId, String key) {
+        CanDoResponse response;
+        if (isValidRequest(eventId, key)) {
+            logger.debug("Event ({}) exists, checking if it could be performed", eventId);
 
-  /**
-   * Indicates that the event has been done.
-   *
-   * @param eventId Event identifier.
-   * @param key     event execution key.
-   * @return <code>true</code> if the event execution has been recorded successfully, <code>false</code> otherwise.
-   */
-  public boolean doEvent(String eventId, String key) {
-    boolean eventRecorded = false;
-    if (isValidRequest(eventId, key)) {
-      EventConfig eventConfig = eventsConfig.get(eventId);
+            String hashedKey = hashText(key);
+            EventConfig eventConfig = eventsConfig.get(eventId);
+            Duration eventTime = eventConfig.minTime();
+            long eventMaxIntents = eventConfig.maxIntents();
+            Instant now = Instant.now();
+            eventsRedisRepository.removeEventsOlderThan(eventId, hashedKey, now.minus(eventTime));
+            long eventIntents = eventsRedisRepository.getEventsCount(eventId, hashedKey);
 
-      eventsRedisRepository.addEvent(eventId, hashText(key), eventConfig.minTime());
-      logger.debug("Event [{}] recorded", eventId);
-      eventRecorded = true;
+            if (eventIntents >= eventMaxIntents) {
+                logger.debug("Checking dates");
+                Instant firstDate = eventsRedisRepository.getOldestEvent(eventId, hashedKey);
+                if (firstDate == null) {
+                    logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
+                    response = CanDoResponse.success(eventIntents);
+                } else {
+                    long millisDifference = ChronoUnit.MILLIS.between(firstDate, now);
+                    response = CanDoResponse.tooMany(Math.max(0, eventTime.toMillis() - millisDifference), eventIntents);
+                }
+            } else {
+                logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
+                response = CanDoResponse.success(eventIntents);
+            }
+        } else {
+            response = CanDoResponse.invalidRequest();
+        }
+
+        if (!response.canDo()) {
+            logger.info("The event: {} could NOT be performed. reason: {}. need to wait: {} ms",
+                    eventId, response.reason(), response.waitMillis());
+        }
+
+        return response;
     }
 
-    return eventRecorded;
-  }
+    /**
+     * Indicates that the event has been done.
+     *
+     * @param eventId Event identifier.
+     * @param key     event execution key.
+     * @return <code>true</code> if the event execution has been recorded successfully, <code>false</code> otherwise.
+     */
+    public boolean doEvent(String eventId, String key) {
+        boolean eventRecorded = false;
+        if (isValidRequest(eventId, key)) {
+            EventConfig eventConfig = eventsConfig.get(eventId);
 
-  /**
-   * Clear all the event execution for the provided key.
-   *
-   * @param eventId Event identifier.
-   * @param key     event execution key.
-   * @return <code>true</code> if the event execution has been cleared successfully, <code>false</code> otherwise.
-   */
-  public boolean reset(String eventId, String key) {
-    boolean eventDeleted = false;
-    if (isValidRequest(eventId, key)) {
-      eventsRedisRepository.remove(eventId, hashText(key));
-      logger.debug("Event [{}] deleted", eventId);
-      eventDeleted = true;
+            eventsRedisRepository.addEvent(eventId, hashText(key), eventConfig.minTime());
+            logger.debug("Event [{}] recorded", eventId);
+            eventRecorded = true;
+        }
+
+        return eventRecorded;
     }
 
-    return eventDeleted;
-  }
+    /**
+     * Clear all the event execution for the provided key.
+     *
+     * @param eventId Event identifier.
+     * @param key     event execution key.
+     * @return <code>true</code> if the event execution has been cleared successfully, <code>false</code> otherwise.
+     */
+    public boolean reset(String eventId, String key) {
+        boolean eventDeleted = false;
+        if (isValidRequest(eventId, key)) {
+            eventsRedisRepository.remove(eventId, hashText(key));
+            logger.debug("Event [{}] deleted", eventId);
+            eventDeleted = true;
+        }
 
-  /**
-   * Get information about an event.
-   *
-   * @param eventId Event identifier.
-   * @return Event configuration.
-   */
-  public Optional<EventConfig> getEventConfig(String eventId) {
-    return Optional.ofNullable(eventsConfig.get(eventId));
-  }
-
-  /**
-   * Hash text using Hasher utility class.
-   *
-   * @param text Text to be hashed.
-   * @return Hashed text.
-   * @see Hasher
-   */
-  private String hashText(String text) {
-    return hashCache.computeIfAbsent(text, s -> {
-      try {
-        return hasher.convertToHmacSHA256(s);
-      } catch (Exception e) {
-        logger.warn("Error hashing text, using clear text: {}", e.getMessage());
-        return s;
-      }
-    });
-  }
-
-  /**
-   * Validates the request. Checks if the key is not blank, and the eventId is configured.
-   */
-  private boolean isValidRequest(String eventId, String key) {
-    boolean valid = false;
-    if (isNotBlank(key)) {
-      logger.debug("Checking the existence of event: {}", eventId);
-      if (eventsConfig.containsKey(eventId)) {
-        valid = true;
-      } else {
-        logger.warn("Invalid request - The eventId [{}] is not found", eventId);
-      }
-    } else {
-      logger.warn("Invalid request - The key is blank");
+        return eventDeleted;
     }
 
-    return valid;
-  }
-
-  /**
-   * Validates no key are duplicated in the events config supplied.
-   *
-   * @param eventConfigs List of event configs to validate.
-   * @throws DuplicatedEventKeyException when a key is duplicated.
-   */
-  private void validateEventsConfig(EventConfig... eventConfigs) {
-    Set<String> keys = new HashSet<>();
-    for (EventConfig cfg : eventConfigs) {
-      String eventId = cfg.eventId();
-      if (!keys.add(eventId)) {
-        throw new DuplicatedEventKeyException(eventId);
-      }
+    /**
+     * Get information about an event.
+     *
+     * @param eventId Event identifier.
+     * @return Event configuration.
+     */
+    public Optional<EventConfig> getEventConfig(String eventId) {
+        return Optional.ofNullable(eventsConfig.get(eventId));
     }
-  }
 
-  /**
-   * <p>Checks if a CharSequence is empty (""), null or whitespace only.</p>
-   *
-   * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
-   *
-   * <p><strong>Copied from Apache Commons StringUtils</strong></p>
-   *
-   * <pre>
-   * isBlank(null)      = true
-   * isBlank("")        = true
-   * isBlank(" ")       = true
-   * isBlank("bob")     = false
-   * isBlank("  bob  ") = false
-   * </pre>
-   *
-   * @param cs the CharSequence to check, may be null
-   * @return {@code true} if the CharSequence is null, empty or whitespace only
-   */
-  private boolean isBlank(CharSequence cs) {
-    int strLen;
-    if (cs == null || (strLen = cs.length()) == 0) {
-      return true;
+    /**
+     * Hash text using Hasher utility class.
+     *
+     * @param text Text to be hashed.
+     * @return Hashed text.
+     * @see Hasher
+     */
+    private String hashText(String text) {
+        synchronized (hashCache) {
+            String cachedValue = hashCache.get(text);
+            if (cachedValue != null) {
+                return cachedValue;
+            }
+
+            try {
+                String hashed = hasher.convertToHmacSHA256(text);
+                hashCache.put(text, hashed);
+                return hashed;
+            } catch (Exception e) {
+                logger.warn("Error hashing text, using clear text: {}", e.getMessage());
+                return text;
+            }
+        }
     }
-    for (int i = 0; i < strLen; i++) {
-      if (!Character.isWhitespace(cs.charAt(i))) {
-        return false;
-      }
+
+    /**
+     * Validates the request. Checks if the key is not blank, and the eventId is configured.
+     */
+    private boolean isValidRequest(String eventId, String key) {
+        boolean valid = false;
+        if (isNotBlank(key)) {
+            logger.debug("Checking the existence of event: {}", eventId);
+            if (eventsConfig.containsKey(eventId)) {
+                valid = true;
+            } else {
+                logger.warn("Invalid request - The eventId [{}] is not found", eventId);
+            }
+        } else {
+            logger.warn("Invalid request - The key is blank");
+        }
+
+        return valid;
     }
-    return true;
-  }
 
-  /**
-   * <p>Checks if a CharSequence is not empty (""), not null and not whitespace only.</p>
-   *
-   * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
-   *
-   * <p><strong>Copied from Apache Commons StringUtils</strong></p>
-   *
-   * <pre>
-   * isNotBlank(null)      = false
-   * isNotBlank("")        = false
-   * isNotBlank(" ")       = false
-   * isNotBlank("bob")     = true
-   * isNotBlank("  bob  ") = true
-   * </pre>
-   *
-   * @param cs the CharSequence to check, may be null
-   * @return {@code true} if the CharSequence is not empty and not null and not whitespace only
-   */
-  private boolean isNotBlank(CharSequence cs) {
-    return !isBlank(cs);
-  }
+    /**
+     * Validates no key are duplicated in the events config supplied.
+     *
+     * @param eventConfigs List of event configs to validate.
+     * @throws DuplicatedEventKeyException when a key is duplicated.
+     */
+    private void validateEventsConfig(EventConfig... eventConfigs) {
+        Set<String> keys = new HashSet<>();
+        for (EventConfig cfg : eventConfigs) {
+            String eventId = cfg.eventId();
+            if (!keys.add(eventId)) {
+                throw new DuplicatedEventKeyException(eventId);
+            }
+        }
+    }
 
-  @Override
-  public void close() {
-    jedisPool.close();
-  }
+    /**
+     * <p>Checks if a CharSequence is empty (""), null or whitespace only.</p>
+     *
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     *
+     * <p><strong>Copied from Apache Commons StringUtils</strong></p>
+     *
+     * <pre>
+     * isBlank(null)      = true
+     * isBlank("")        = true
+     * isBlank(" ")       = true
+     * isBlank("bob")     = false
+     * isBlank("  bob  ") = false
+     * </pre>
+     *
+     * @param cs the CharSequence to check, may be null
+     * @return {@code true} if the CharSequence is null, empty or whitespace only
+     */
+    private boolean isBlank(CharSequence cs) {
+        int strLen;
+        if (cs == null || (strLen = cs.length()) == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (!Character.isWhitespace(cs.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * <p>Checks if a CharSequence is not empty (""), not null and not whitespace only.</p>
+     *
+     * <p>Whitespace is defined by {@link Character#isWhitespace(char)}.</p>
+     *
+     * <p><strong>Copied from Apache Commons StringUtils</strong></p>
+     *
+     * <pre>
+     * isNotBlank(null)      = false
+     * isNotBlank("")        = false
+     * isNotBlank(" ")       = false
+     * isNotBlank("bob")     = true
+     * isNotBlank("  bob  ") = true
+     * </pre>
+     *
+     * @param cs the CharSequence to check, may be null
+     * @return {@code true} if the CharSequence is not empty and not null and not whitespace only
+     */
+    private boolean isNotBlank(CharSequence cs) {
+        return !isBlank(cs);
+    }
+
+    @Override
+    public void close() {
+        jedisPool.close();
+    }
 }

--- a/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
+++ b/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
@@ -75,19 +75,19 @@ public class RateLimiter implements Closeable {
       EventConfig eventConfig = eventsConfig.get(eventId);
       Duration eventTime = eventConfig.minTime();
       long eventMaxIntents = eventConfig.maxIntents();
-      long eventIntents = eventsRedisRepository.getListLength(eventId, hashedKey);
+      Instant now = Instant.now();
+      eventsRedisRepository.removeEventsOlderThan(eventId, hashedKey, now.minus(eventTime));
+      long eventIntents = eventsRedisRepository.getEventsCount(eventId, hashedKey);
 
       if (eventIntents >= eventMaxIntents) {
         logger.debug("Checking dates");
-        Instant firstDate = eventsRedisRepository.getListFirstEventElement(eventId, hashedKey, eventMaxIntents);
-        long millisDifference = ChronoUnit.MILLIS.between(firstDate, Instant.now());
-
-        if (millisDifference > eventTime.toMillis()) {
-          eventsRedisRepository.removeListFirstElement(eventId, hashedKey);
+        Instant firstDate = eventsRedisRepository.getOldestEvent(eventId, hashedKey);
+        if (firstDate == null) {
           logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
           response = CanDoResponse.success(eventIntents);
         } else {
-          response = CanDoResponse.tooMany(eventTime.toMillis() - millisDifference, eventIntents);
+          long millisDifference = ChronoUnit.MILLIS.between(firstDate, now);
+          response = CanDoResponse.tooMany(Math.max(0, eventTime.toMillis() - millisDifference), eventIntents);
         }
       } else {
         logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);

--- a/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
+++ b/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
@@ -181,10 +181,10 @@ public class RateLimiter implements Closeable {
       if (eventsConfig.containsKey(eventId)) {
         valid = true;
       } else {
-        logger.error("Invalid request - The eventId [{}] is not found", eventId);
+        logger.warn("Invalid request - The eventId [{}] is not found", eventId);
       }
     } else {
-      logger.error("Invalid request - The key is blank");
+      logger.warn("Invalid request - The key is blank");
     }
 
     return valid;

--- a/src/test/java/org/sputnik/ratelimit/dao/EventsRedisRepositoryTest.java
+++ b/src/test/java/org/sputnik/ratelimit/dao/EventsRedisRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.redis.testcontainers.RedisContainer;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,92 +46,75 @@ class EventsRedisRepositoryTest {
   @Test
   void testAddEvent() {
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    assertThat(redisClient.llen(eventKey(TEST_EVENT_ID, TEST_KEY))).isOne();
+    assertThat(redisClient.zcard(eventKey(TEST_EVENT_ID, TEST_KEY))).isOne();
   }
 
   @Test
   void testAddEventExpiration() throws InterruptedException {
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, Duration.ofMillis(1000));
-    assertThat(redisClient.llen(eventKey(TEST_EVENT_ID, TEST_KEY))).isOne();
+    assertThat(redisClient.zcard(eventKey(TEST_EVENT_ID, TEST_KEY))).isOne();
     TimeUnit.MILLISECONDS.sleep(1200);
-    assertThat(redisClient.llen(eventKey(TEST_EVENT_ID, TEST_KEY))).isZero();
+    assertThat(redisClient.zcard(eventKey(TEST_EVENT_ID, TEST_KEY))).isZero();
   }
 
   @Test
   void testRemoveEvent() {
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    assertThat(redisClient.llen(eventKey(TEST_EVENT_ID, TEST_KEY))).isOne();
+    assertThat(redisClient.zcard(eventKey(TEST_EVENT_ID, TEST_KEY))).isOne();
     eventsRedisRepository.remove(TEST_EVENT_ID, TEST_KEY);
-    assertThat(redisClient.llen(eventKey(TEST_EVENT_ID, TEST_KEY))).isZero();
+    assertThat(redisClient.zcard(eventKey(TEST_EVENT_ID, TEST_KEY))).isZero();
   }
 
   @Test
-  void testGetListLength() {
+  void testGetEventsCount() {
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
+    assertThat(eventsRedisRepository.getEventsCount(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
   }
 
   @Test
-  void testGetListFirstElement() throws InterruptedException {
+  void testGetOldestEvent() throws InterruptedException {
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
     TimeUnit.MILLISECONDS.sleep(100);
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
     TimeUnit.MILLISECONDS.sleep(100);
     eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
-    String firstElement = redisClient.lindex(eventKey(TEST_EVENT_ID, TEST_KEY), 0);
-    assertThat(eventsRedisRepository.getListFirstElement(TEST_EVENT_ID, TEST_KEY).toEpochMilli()).isEqualTo(Long.parseLong(firstElement));
+    assertThat(eventsRedisRepository.getEventsCount(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
+    Double firstScore = redisClient.zscore(eventKey(TEST_EVENT_ID, TEST_KEY), redisClient.zrange(eventKey(TEST_EVENT_ID, TEST_KEY), 0, 0).iterator().next());
+    assertThat(eventsRedisRepository.getOldestEvent(TEST_EVENT_ID, TEST_KEY).toEpochMilli()).isEqualTo(firstScore.longValue());
   }
 
   @Test
-  void testGetListFirstElementWrongFormat() {
-    redisClient.rpush(eventKey(TEST_EVENT_ID, TEST_KEY), "A", "B", "C");
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
-    assertThat(eventsRedisRepository.getListFirstElement(TEST_EVENT_ID, TEST_KEY)).isNull();
+  void testGetOldestEventEmpty() {
+    assertThat(eventsRedisRepository.getOldestEvent(TEST_EVENT_ID, TEST_KEY)).isNull();
   }
 
   @Test
-  void testGetListFirstEventElement() throws InterruptedException {
-    eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    TimeUnit.MILLISECONDS.sleep(100);
-    eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    TimeUnit.MILLISECONDS.sleep(100);
-    eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
-    String firstElement = redisClient.lindex(eventKey(TEST_EVENT_ID, TEST_KEY), 1);
-    assertThat(eventsRedisRepository.getListFirstEventElement(TEST_EVENT_ID, TEST_KEY, 2L).toEpochMilli())
-      .isEqualTo(Long.parseLong(firstElement));
+  void testRemoveEventsOlderThan() {
+    String key = eventKey(TEST_EVENT_ID, TEST_KEY);
+    long now = System.currentTimeMillis();
+    redisClient.zadd(key, now - 10_000, "old-1");
+    redisClient.zadd(key, now - 5_000, "old-2");
+    redisClient.zadd(key, now - 500, "new-1");
+    redisClient.zadd(key, now, "new-2");
+
+    long removed = eventsRedisRepository.removeEventsOlderThan(TEST_EVENT_ID, TEST_KEY, Instant.ofEpochMilli(now - 1_000));
+    assertThat(removed).isEqualTo(2);
+    assertThat(eventsRedisRepository.getEventsCount(TEST_EVENT_ID, TEST_KEY)).isEqualTo(2);
   }
 
   @Test
-  void testGetListFirstEventElementWrongFormat() {
-    redisClient.rpush(eventKey(TEST_EVENT_ID, TEST_KEY), "A", "B", "C");
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
-    assertThat(eventsRedisRepository.getListFirstEventElement(TEST_EVENT_ID, TEST_KEY, 2L)).isNull();
-  }
+  void testRemoveEventsOlderThanBoundaryExclusive() {
+    String key = eventKey(TEST_EVENT_ID, TEST_KEY);
+    long threshold = System.currentTimeMillis() - 2_000;
+    redisClient.zadd(key, threshold - 1, "old");
+    redisClient.zadd(key, threshold, "boundary");
+    redisClient.zadd(key, threshold + 1, "new");
 
-  @Test
-  void testRemoveListFirstElement() throws InterruptedException {
-    eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    TimeUnit.MILLISECONDS.sleep(100);
-    eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    TimeUnit.MILLISECONDS.sleep(100);
-    eventsRedisRepository.addEvent(TEST_EVENT_ID, TEST_KEY, TEST_TIMEOUT);
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
-    String firstElement = redisClient.lindex(eventKey(TEST_EVENT_ID, TEST_KEY), 0);
-    assertThat(eventsRedisRepository.removeListFirstElement(TEST_EVENT_ID, TEST_KEY).toEpochMilli())
-      .isEqualTo(Long.parseLong(firstElement));
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(2);
-  }
-
-  @Test
-  void testRemoveListFirstElementWrongFormat() {
-    redisClient.rpush(eventKey(TEST_EVENT_ID, TEST_KEY), "A", "B", "C");
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(3);
-    assertThat(eventsRedisRepository.removeListFirstElement(TEST_EVENT_ID, TEST_KEY)).isNull();
-    assertThat(eventsRedisRepository.getListLength(TEST_EVENT_ID, TEST_KEY)).isEqualTo(2);
+    long removed = eventsRedisRepository.removeEventsOlderThan(TEST_EVENT_ID, TEST_KEY, Instant.ofEpochMilli(threshold));
+    assertThat(removed).isOne();
+    assertThat(eventsRedisRepository.getEventsCount(TEST_EVENT_ID, TEST_KEY)).isEqualTo(2);
   }
 
   private String eventKey(String eventId, String key) {


### PR DESCRIPTION
## Summary
- migrate event persistence from Redis Lists to Sorted Sets
- prune by score window and count with sorted-set operations
- update limiter flow and repository tests to sorted-set semantics
- use UUID members for unique attempts
- downgrade invalid-request logs to WARN
- bound hash cache using JDK-only LRU map to avoid unbounded growth

## Notes
- no new runtime dependencies added