### PR TITLE
Clean API naming and fix exception package typo

### DIFF
--- a/src/main/java/org/sputnik/ratelimit/domain/CanDoResponse.java
+++ b/src/main/java/org/sputnik/ratelimit/domain/CanDoResponse.java
@@ -1,18 +1,18 @@
 package org.sputnik.ratelimit.domain;
 
-public record CanDoResponse(boolean canDo, long waitMillis, Reason reason, long eventsIntents) {
+public record CanDoResponse(boolean canDo, long waitMillis, Reason reason, long eventAttempts) {
 
   public enum Reason {INVALID_REQUEST, TOO_MANY_EVENTS}
 
-  public static CanDoResponse success(long currentIntents) {
-    return new CanDoResponse(true, 0, null, currentIntents);
+  public static CanDoResponse success(long currentAttempts) {
+    return new CanDoResponse(true, 0, null, currentAttempts);
   }
 
   public static CanDoResponse invalidRequest() {
     return new CanDoResponse(false, 0, Reason.INVALID_REQUEST, 0);
   }
 
-  public static CanDoResponse tooMany(long waitMillis, long intents) {
-    return new CanDoResponse(false, waitMillis, Reason.TOO_MANY_EVENTS, intents);
+  public static CanDoResponse tooMany(long waitMillis, long attempts) {
+    return new CanDoResponse(false, waitMillis, Reason.TOO_MANY_EVENTS, attempts);
   }
 }

--- a/src/main/java/org/sputnik/ratelimit/exception/DuplicatedEventKeyException.java
+++ b/src/main/java/org/sputnik/ratelimit/exception/DuplicatedEventKeyException.java
@@ -1,4 +1,4 @@
-package org.sputnik.ratelimit.exeception;
+package org.sputnik.ratelimit.exception;
 
 public class DuplicatedEventKeyException extends RuntimeException {
 

--- a/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
+++ b/src/main/java/org/sputnik/ratelimit/service/RateLimiter.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sputnik.ratelimit.dao.EventsRedisRepository;
 import org.sputnik.ratelimit.domain.CanDoResponse;
-import org.sputnik.ratelimit.exeception.DuplicatedEventKeyException;
+import org.sputnik.ratelimit.exception.DuplicatedEventKeyException;
 import org.sputnik.ratelimit.util.EventConfig;
 import org.sputnik.ratelimit.util.Hasher;
 import redis.clients.jedis.JedisPool;
@@ -80,24 +80,24 @@ public class RateLimiter implements Closeable {
             String hashedKey = hashText(key);
             EventConfig eventConfig = eventsConfig.get(eventId);
             Duration eventTime = eventConfig.minTime();
-            long eventMaxIntents = eventConfig.maxIntents();
+            long eventMaxAttempts = eventConfig.maxAttempts();
             Instant now = Instant.now();
             eventsRedisRepository.removeEventsOlderThan(eventId, hashedKey, now.minus(eventTime));
-            long eventIntents = eventsRedisRepository.getEventsCount(eventId, hashedKey);
+            long eventAttempts = eventsRedisRepository.getEventsCount(eventId, hashedKey);
 
-            if (eventIntents >= eventMaxIntents) {
+            if (eventAttempts >= eventMaxAttempts) {
                 logger.debug("Checking dates");
                 Instant firstDate = eventsRedisRepository.getOldestEvent(eventId, hashedKey);
                 if (firstDate == null) {
-                    logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
-                    response = CanDoResponse.success(eventIntents);
+                    logger.info("Event [{}] could be performed [{}/{}]", eventId, eventAttempts, eventMaxAttempts);
+                    response = CanDoResponse.success(eventAttempts);
                 } else {
                     long millisDifference = ChronoUnit.MILLIS.between(firstDate, now);
-                    response = CanDoResponse.tooMany(Math.max(0, eventTime.toMillis() - millisDifference), eventIntents);
+                    response = CanDoResponse.tooMany(Math.max(0, eventTime.toMillis() - millisDifference), eventAttempts);
                 }
             } else {
-                logger.info("Event [{}] could be performed [{}/{}]", eventId, eventIntents, eventMaxIntents);
-                response = CanDoResponse.success(eventIntents);
+                logger.info("Event [{}] could be performed [{}/{}]", eventId, eventAttempts, eventMaxAttempts);
+                response = CanDoResponse.success(eventAttempts);
             }
         } else {
             response = CanDoResponse.invalidRequest();

--- a/src/main/java/org/sputnik/ratelimit/util/EventConfig.java
+++ b/src/main/java/org/sputnik/ratelimit/util/EventConfig.java
@@ -4,16 +4,16 @@ import java.time.Duration;
 import java.util.Objects;
 
 /**
- * Immutable event configuration. maxIntents: max events allowed inside minTime sliding window.
+ * Immutable event configuration. maxAttempts: max events allowed inside minTime sliding window.
  */
-public record EventConfig(String eventId, long maxIntents, Duration minTime) {
+public record EventConfig(String eventId, long maxAttempts, Duration minTime) {
 
   public EventConfig {
     if (eventId == null || eventId.isBlank()) {
       throw new IllegalArgumentException("eventId must not be blank");
     }
-    if (maxIntents <= 0) {
-      throw new IllegalArgumentException("maxIntents must be > 0");
+    if (maxAttempts <= 0) {
+      throw new IllegalArgumentException("maxAttempts must be > 0");
     }
     Objects.requireNonNull(minTime, "minTime");
     if (minTime.isZero() || minTime.isNegative()) {

--- a/src/test/java/org/sputnik/ratelimit/service/RateLimiterTest.java
+++ b/src/test/java/org/sputnik/ratelimit/service/RateLimiterTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.sputnik.ratelimit.domain.CanDoResponse;
 import org.sputnik.ratelimit.domain.CanDoResponse.Reason;
-import org.sputnik.ratelimit.exeception.DuplicatedEventKeyException;
+import org.sputnik.ratelimit.exception.DuplicatedEventKeyException;
 import org.sputnik.ratelimit.util.EventConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;


### PR DESCRIPTION
Summary: rename API terms from intents to attempts, update RateLimiter internals, fix exception package typo (exeception to exception), and update tests. Release impact: breaking API change for next major version.